### PR TITLE
chore: 계정 관련 메일의 도메인 주소를 정정합니다

### DIFF
--- a/config/locales/devise.ko.yml
+++ b/config/locales/devise.ko.yml
@@ -28,16 +28,16 @@ ko:
     mailer:
       confirmation_instructions:
         confirm: "내 계정 확인하기"
-        subject: "parti.xyz 계정 확인"
+        subject: "campaigns.kr 계정 확인"
         you_can_confirm: "아래 링크로 계정을 확인할 수 있습니다:"
       hello: "%{email}님!"
       password_change:
-        subject: "parti.xyz 계정 비밀번호 변경됨"
+        subject: "campaigns.kr 계정 비밀번호 변경됨"
       reset_password_instructions:
         change: "비밀번호 바꾸기"
         ignore: "비밀번호 초기화를 요청하지 않았다면 이 메일을 무시하세요."
         someone_requested: "아래 링크로 비밀번호를 다시 정할 수 있습니다:"
-        subject: "parti.xyz 비밀번호 재설정"
+        subject: "campaigns.kr 비밀번호 재설정"
         wont_change: "비밀번호는 링크를 클릭해서 새 비밀번호를 만들기 전까지 바뀌지 않습니다."
       unlock_instructions:
         account_locked: "귀하의 계정은 많은 양의 로그인 실패로 인해 잠겨있습니다."


### PR DESCRIPTION
비밀번호 찾기 메일 제목에 엉뚱한 주소가 나와서 고쳐봤습니다.